### PR TITLE
Hide tab bar in closet/wishlist add and filter subviews

### DIFF
--- a/closet/Filter/ItemFilterView.swift
+++ b/closet/Filter/ItemFilterView.swift
@@ -223,6 +223,7 @@ struct ItemFilterView: View {
                 }
             }
         }
+        .toolbar(.hidden, for: .tabBar)
     }
 }
 

--- a/closet/Filter/OutfitFilterView.swift
+++ b/closet/Filter/OutfitFilterView.swift
@@ -58,6 +58,7 @@ struct OutfitFilterView: View {
                 }
             }
         }
+        .toolbar(.hidden, for: .tabBar)
     }
 }
 

--- a/closet/Item View/Add Item/ItemAddView.swift
+++ b/closet/Item View/Add Item/ItemAddView.swift
@@ -121,6 +121,7 @@ struct ItemAddView: View {
             "Add Item")
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
+        .toolbar(.hidden, for: .tabBar)
         // Only ONE navigationDestination — solely for the image cropper
         .navigationDestination(item: $cropperDestination) { destination in
             if case .cropper(let imageType, let image) = destination {

--- a/closet/Outfit Views/OutfitAddView.swift
+++ b/closet/Outfit Views/OutfitAddView.swift
@@ -492,6 +492,7 @@ struct OutfitAddView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
+        .toolbar(.hidden, for: .tabBar)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 wardrobeSelectionButton


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- hide the tab bar when entering `ItemAddView`
- hide the tab bar for `ItemFilterView` and `OutfitFilterView`
- hide the tab bar for `OutfitAddView`

## Why
When users enter these toolbar-driven sub-level flows from Closet/Wishlist, the tab bar remained visible and allowed accidental tab switches mid-action. Hiding it better communicates sub-level context and keeps users focused until they navigate back.

## Testing
- Verified code paths and modifiers in:
  - `closet/Item View/Add Item/ItemAddView.swift`
  - `closet/Filter/ItemFilterView.swift`
  - `closet/Filter/OutfitFilterView.swift`
  - `closet/Outfit Views/OutfitAddView.swift`
- Runtime UI testing not executed in this Linux cloud environment (requires iOS simulator/Xcode).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af280d38-1c1d-48d1-9868-027708ce2261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af280d38-1c1d-48d1-9868-027708ce2261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

